### PR TITLE
Making Packet Sendable

### DIFF
--- a/Sources/RTP/Packet.swift
+++ b/Sources/RTP/Packet.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // Packet represents an individual RTP packet.
-public struct Packet {
+public struct Packet: Sendable {
 	static let version: UInt8 = 2
 	static let versionMask: UInt8 = 0b1100_0000
 	static let paddingMask: UInt8 = 0b0010_0000
@@ -172,7 +172,7 @@ public struct Packet {
 }
 
 // Extension represents an RTP extension.
-public struct Extension {
+public struct Extension: Sendable {
 	public typealias ProfileID = UInt16
 
 	static let headerSize = 4

--- a/Sources/RTP/Types.swift
+++ b/Sources/RTP/Types.swift
@@ -10,7 +10,7 @@ public enum EncodingError: Error {
 	case tooManyCSRCs(_ count: Int)
 }
 
-public struct PayloadType: ExpressibleByIntegerLiteral, RawRepresentable, Equatable {
+public struct PayloadType: ExpressibleByIntegerLiteral, RawRepresentable, Equatable, Sendable {
 	public typealias IntegerLiteralType = UInt8
 
 	public static let marker: Self = 0b1000_0000


### PR DESCRIPTION
So this makes packet (and a few sub-structs) sendable. 

This, however is not sufficient for this package to be built with swift 6 mode. That would probably require making `Connection` an actor or doing some other trickery to ensure that callbacks to `contentProcessed` are threadsafe, and I don't have time to do that right now. 

If you would like to see that, I can come back through this later with another PR. Just let me know what you think.